### PR TITLE
Fix for newest GCC 10 as well as unresolved symbols in gold/errors.h

### DIFF
--- a/gas/config/tc-i386.c
+++ b/gas/config/tc-i386.c
@@ -11322,9 +11322,9 @@ md_parse_option (int c, const char *arg)
 
     case OPTION_MVEXWIG:
       if (strcmp (arg, "0") == 0)
-	vexwig = evexw0;
+	vexwig = vexw0;
       else if (strcmp (arg, "1") == 0)
-	vexwig = evexw1;
+	vexwig = vexw1;
       else
 	as_fatal (_("invalid -mvexwig= option: `%s'"), arg);
       break;

--- a/gold/errors.h
+++ b/gold/errors.h
@@ -24,7 +24,7 @@
 #define GOLD_ERRORS_H
 
 #include <cstdarg>
-
+#include <string>
 #include "gold-threads.h"
 
 namespace gold


### PR DESCRIPTION
upstream for tc-i386.c
https://github.com/bminor/binutils-gdb/commit/40c9c8deb94be6576f5729172dce117cbe155856

upstream for gold/errors.h
https://github.com/bminor/binutils-gdb/commit/a3972330f49f81b3bea64af0970d22f42ae56ec3