### PR TITLE
Fixes for GCC 11

### DIFF
--- a/bfd/plugin.c
+++ b/bfd/plugin.c
@@ -394,13 +394,15 @@ load_plugin (bfd *abfd)
     {
       char *full_name;
       struct stat s;
-      int valid_plugin;
 
       full_name = concat (p, "/", ent->d_name, NULL);
-      if (stat (full_name, &s) == 0 && S_ISREG (s.st_mode))
-	found = try_load_plugin (full_name, abfd, &valid_plugin);
-      if (has_plugin <= 0)
-	has_plugin = valid_plugin;
+      if (stat (full_name, &s) == 0 && S_ISREG (s.st_mode)) {
+        int valid_plugin;
+
+        found = try_load_plugin (full_name, abfd, &valid_plugin);
+        if (has_plugin <= 0)
+          has_plugin = valid_plugin;
+      }
       free (full_name);
       if (found)
 	break;

--- a/gold/config.in
+++ b/gold/config.in
@@ -115,6 +115,9 @@
 /* Define to 1 if you have the `mallinfo' function. */
 #undef HAVE_MALLINFO
 
+/* Define to 1 if you have the `mallinfo2' function. */
+#undef HAVE_MALLINFO2
+
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 

--- a/gold/configure
+++ b/gold/configure
@@ -9908,7 +9908,7 @@ case "$ac_cv_search_dlopen" in
 esac
 
 
-for ac_func in mallinfo posix_fallocate fallocate readv sysconf times mkdtemp
+for ac_func in mallinfo mallinfo2 posix_fallocate fallocate readv sysconf times mkdtemp
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_cxx_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/gold/configure.ac
+++ b/gold/configure.ac
@@ -628,7 +628,7 @@ case "$ac_cv_search_dlopen" in
 esac
 AC_SUBST(DLOPEN_LIBS)
 
-AC_CHECK_FUNCS(mallinfo posix_fallocate fallocate readv sysconf times mkdtemp)
+AC_CHECK_FUNCS(mallinfo mallinfo2 posix_fallocate fallocate readv sysconf times mkdtemp)
 AC_CHECK_DECLS([basename, ffs, asprintf, vasprintf, snprintf, vsnprintf, strverscmp, strndup, memmem])
 
 # Use of ::std::tr1::unordered_map::rehash causes undefined symbols

--- a/gold/main.cc
+++ b/gold/main.cc
@@ -25,7 +25,7 @@
 #include <cstdio>
 #include <cstring>
 
-#ifdef HAVE_MALLINFO
+#if defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)
 #ifdef __DJGPP__
 extern "C"
 {
@@ -297,11 +297,16 @@ main(int argc, char** argv)
               elapsed.sys / 1000, (elapsed.sys % 1000) * 1000,
               elapsed.wall / 1000, (elapsed.wall % 1000) * 1000);
 
-#ifdef HAVE_MALLINFO
+#if defined(HAVE_MALLINFO2)
+      struct mallinfo2 m = mallinfo2();
+      fprintf(stderr, _("%s: total space allocated by malloc: %lld bytes\n"),
+	      program_name, static_cast<long long>(m.arena));
+#elif defined(HAVE_MALLINFO)
       struct mallinfo m = mallinfo();
       fprintf(stderr, _("%s: total space allocated by malloc: %lld bytes\n"),
 	      program_name, static_cast<long long>(m.arena));
 #endif
+
       File_read::print_stats();
       Archive::print_stats();
       Lib_group::print_stats();


### PR DESCRIPTION
Just a couple of fixes for GCC 11, which currently fails (when launched with `./configure --target=ia16-elf --enable-ld=default --enable-gold=yes --enable-targets=ia16-elf --enable-x86-hpa-segelf=yes --disable-gdb --disable-libdecnumber --disable-readline --disable-sim --disable-nls && make`) due to `Werror` caused by deprecated `mallinfo` (fixed in upstream in 4ee6049, 9331846, and cc18497) and uninitialized `valid_plugin` variable (included by upstream in 41f37a6fb71f2a3de388108f5cdfca9cbe6e9d51).