### PR TITLE
DWARF2 debug support patches + default i8086 arch (binutils side)

### DIFF
--- a/bfd/config.bfd
+++ b/bfd/config.bfd
@@ -770,7 +770,7 @@ case "${targ}" in
     ;;
 
   ia16-*-elf)
-    targ_defvec=i386_elf32_vec
+    targ_defvec=i386_elf32_i8086_vec
     targ_selvecs="i386_elks_vec i386_msdos_vec i386_aout_vec"
     ;;
 

--- a/bfd/configure
+++ b/bfd/configure
@@ -13440,6 +13440,7 @@ do
     i386_coff_lynx_vec)		 tb="$tb cf-i386lynx.lo lynx-core.lo $coff" ;;
     i386_elf32_vec)		 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
     i386_elf32_fbsd_vec)	 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
+    i386_elf32_i8086_vec)	 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
     i386_elf32_sol2_vec)	 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
     i386_elf32_vxworks_vec)	 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
     i386_elks_vec)		 tb="$tb i386elks.lo" ;;

--- a/bfd/configure.ac
+++ b/bfd/configure.ac
@@ -485,6 +485,7 @@ do
     i386_coff_lynx_vec)		 tb="$tb cf-i386lynx.lo lynx-core.lo $coff" ;;
     i386_elf32_vec)		 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
     i386_elf32_fbsd_vec)	 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
+    i386_elf32_i8086_vec)	 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
     i386_elf32_sol2_vec)	 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
     i386_elf32_vxworks_vec)	 tb="$tb elf32-i386.lo $elfxx_x86 elf32.lo $elf" ;;
     i386_elks_vec)		 tb="$tb i386elks.lo" ;;

--- a/bfd/elf32-i386.c
+++ b/bfd/elf32-i386.c
@@ -4738,6 +4738,30 @@ elf_i386_link_setup_gnu_properties (struct bfd_link_info *info)
 
 #include "elf32-target.h"
 
+/* IA-16 support. */
+/* FIXME?: For the time being, we still claim to be elf32-i386. */
+
+static bool
+elf32_i8086_elf_object_p (bfd *abfd)
+{
+  /* Set the right machine number for an IA-16 ELF file.  */
+  bfd_default_set_arch_mach (abfd, bfd_arch_i386, bfd_mach_i386_i8086);
+  return true;
+}
+
+#undef  TARGET_LITTLE_SYM
+#define TARGET_LITTLE_SYM		i386_elf32_i8086_vec
+
+#undef	elf_backend_object_p
+#define elf_backend_object_p		elf32_i8086_elf_object_p
+
+#undef	elf32_bed
+#define	elf32_bed				elf32_i386_i8086_bed
+
+#include "elf32-target.h"
+
+#undef	elf_backend_object_p
+
 /* FreeBSD support.  */
 
 #undef	TARGET_LITTLE_SYM

--- a/bfd/targets.c
+++ b/bfd/targets.c
@@ -747,6 +747,7 @@ extern const bfd_target i386_coff_go32stubbed_vec;
 extern const bfd_target i386_coff_lynx_vec;
 extern const bfd_target i386_elf32_vec;
 extern const bfd_target i386_elf32_fbsd_vec;
+extern const bfd_target i386_elf32_i8086_vec;
 extern const bfd_target i386_elf32_sol2_vec;
 extern const bfd_target i386_elf32_vxworks_vec;
 extern const bfd_target i386_elks_vec;
@@ -1093,6 +1094,7 @@ static const bfd_target * const _bfd_target_vector[] =
 	&i386_coff_lynx_vec,
 	&i386_elf32_vec,
 	&i386_elf32_fbsd_vec,
+	&i386_elf32_i8086_vec,
 	&i386_elf32_sol2_vec,
 	&i386_elf32_vxworks_vec,
 	&i386_mach_o_vec,

--- a/gas/config/tc-i386.c
+++ b/gas/config/tc-i386.c
@@ -2925,6 +2925,10 @@ i386_mach (void)
       else
 	return bfd_mach_x64_32;
     }
+  else if (!strncmp (default_arch, "i8086", 5))
+    {
+      return bfd_mach_i386_i8086;
+    }
   else if (!strncmp (default_arch, "i386", 4)
 	   || !strcmp (default_arch, "iamcu"))
     {
@@ -3089,6 +3093,11 @@ md_begin (void)
       x86_dwarf2_return_column = 16;
 #endif
       x86_cie_data_alignment = -8;
+    }
+  else if (flag_code == CODE_16BIT)
+    {
+      x86_dwarf2_return_column = 8;
+      x86_cie_data_alignment = -2;
     }
   else
     {
@@ -13284,6 +13293,7 @@ const char *md_shortopts = "qnO::";
 #define OPTION_MLFENCE_BEFORE_RET (OPTION_MD_BASE + 33)
 #define OPTION_MUSE_UNALIGNED_VECTOR_MOVE (OPTION_MD_BASE + 34)
 #define OPTION_32_SEGELF (OPTION_MD_BASE + 35)
+#define OPTION_16_SEGELF (OPTION_MD_BASE + 36)
 
 struct option md_longopts[] =
 {
@@ -13295,6 +13305,7 @@ struct option md_longopts[] =
 #if defined (OBJ_ELF) || defined (OBJ_MAYBE_ELF)
 # ifdef ENABLE_X86_HPA_SEGELF
   {"32-segelf", no_argument, NULL, OPTION_32_SEGELF},
+  {"16-segelf", no_argument, NULL, OPTION_16_SEGELF},
 # endif
   {"x32", no_argument, NULL, OPTION_X32},
   {"mshared", no_argument, NULL, OPTION_MSHARED},
@@ -13438,6 +13449,9 @@ md_parse_option (int c, const char *arg)
 # ifdef ENABLE_X86_HPA_SEGELF
     case OPTION_32_SEGELF:
       default_arch = "i386:segelf";
+      break;
+    case OPTION_16_SEGELF:
+      default_arch = "i8086:segelf";
       break;
 # endif
 #endif
@@ -14161,6 +14175,14 @@ i386_target_format (void)
       update_code_flag (CODE_32BIT, 1);
 # ifdef ENABLE_X86_HPA_SEGELF
       if (default_arch[4] != 0)
+	x86_elf_abi = I386_SEGELF_ABI;
+# endif
+    }
+  else if (!strncmp (default_arch, "i8086", 5))
+    {
+      update_code_flag (CODE_16BIT, 1);
+# ifdef ENABLE_X86_HPA_SEGELF
+      if (default_arch[5] != 0)
 	x86_elf_abi = I386_SEGELF_ABI;
 # endif
     }

--- a/gas/configure.tgt
+++ b/gas/configure.tgt
@@ -62,7 +62,7 @@ case ${cpu} in
   fido)			cpu_type=m68k ;;
   hppa*)		cpu_type=hppa ;;
   i[3-7]86)		cpu_type=i386 arch=i386;;
-  ia16)			cpu_type=i386 arch=i386;;
+  ia16)			cpu_type=i386 arch=i8086;;
   ia64)			cpu_type=ia64 ;;
   ip2k)			cpu_type=ip2k endian=big ;;
   iq2000)		cpu_type=iq2000 endian=big ;;
@@ -263,8 +263,6 @@ case ${generic_target} in
   i386-*-*nt*)				fmt=coff em=pe ;;
   i386-*-rdos*)				fmt=elf ;;
   i386-*-darwin*)			fmt=macho ;;
-
-  ia16-*-elf*)				fmt=elf ;;
 
   ia16-*-elf*)				fmt=elf ;;
 


### PR DESCRIPTION
This merge request hopes to achieve two things:

* Add and use a default "i8086" architecture - this removes the need to specify `-m i8086` in certain `objdump` calls, and also is necessary to effectively achieve the next point,
* Fix DWARF2 data alignment for IA-16.

This is a draft pull request, as while DWARF2 debug data is emitted, at least with regards to types and line numbers (with the proper GCC patch - see matching gcc-ia16 PR), and it looks correct to my eye, something still appears broken. (However, I do not think this is a blocker for potentially merging this PR, as no regressions are caused to my eye - while the GCC-side PR is dependent on the binutils-side PR, the opposite is not the case.)